### PR TITLE
[BE] 스터디룸 관련 테스트코드 작성 및 오류 수정

### DIFF
--- a/server/src/main/java/com/oddok/server/domain/studyroom/api/request/CreateStudyRoomRequest.java
+++ b/server/src/main/java/com/oddok/server/domain/studyroom/api/request/CreateStudyRoomRequest.java
@@ -2,6 +2,8 @@ package com.oddok.server.domain.studyroom.api.request;
 
 import lombok.*;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -9,16 +11,15 @@ import java.util.List;
 @NoArgsConstructor
 public class CreateStudyRoomRequest {
 
+    @NotBlank
     private String name;
 
+    @NotBlank
     private String category;
-
-    private Long userId;
-
-    private String sessionId;
 
     private String image;
 
+    @NotNull
     private Boolean isPublic;
 
     private String password;

--- a/server/src/main/java/com/oddok/server/domain/studyroom/application/StudyRoomService.java
+++ b/server/src/main/java/com/oddok/server/domain/studyroom/application/StudyRoomService.java
@@ -78,7 +78,7 @@ public class StudyRoomService {
      * 해당 스터디룸의 sessionId 가 없으면 Openvidu 세션을 생성/등록 후 반환하고, 있으면 해당 세션아이디를 반환합니다.
      */
     private String getSession(StudyRoom studyRoom) {
-        if (studyRoom.getSessionId() == null) studyRoom.createSession(sessionManager.createSession());
+        if (studyRoom.getSessionId() == null || studyRoom.getSessionId().isBlank()) studyRoom.createSession(sessionManager.createSession());
         return studyRoom.getSessionId();
     }
 
@@ -118,8 +118,8 @@ public class StudyRoomService {
         participantRepository.delete(participant);
         if (studyRoom.decreaseCurrentUsers() == 0) { // 모두 나갔으면 세션삭제
             sessionManager.deleteSession(studyRoom.getSessionId());
+            studyRoom.deleteSession();
         }
-        studyRoom.deleteSession();
     }
 
 

--- a/server/src/main/java/com/oddok/server/domain/studyroom/entity/StudyRoom.java
+++ b/server/src/main/java/com/oddok/server/domain/studyroom/entity/StudyRoom.java
@@ -82,14 +82,13 @@ public class StudyRoom {
 
     @Builder
     public StudyRoom(String name, String category, User user,
-                     String sessionId, String image, Boolean isPublic,
+                     String image, Boolean isPublic,
                      String password, Integer targetTime, String rule,
                      Boolean isMicOn, Boolean isCamOn, Integer limitUsers,
                      LocalDateTime startAt, LocalDateTime endAt) {
         this.name = name;
         this.category = Category.valueOf(category);
         this.user = user;
-        this.sessionId = sessionId;
         this.image = image;
         this.isPublic = isPublic;
         this.password = password;

--- a/server/src/main/java/com/oddok/server/domain/studyroom/mapper/StudyRoomDtoMapper.java
+++ b/server/src/main/java/com/oddok/server/domain/studyroom/mapper/StudyRoomDtoMapper.java
@@ -8,7 +8,6 @@ import com.oddok.server.domain.studyroom.api.response.UpdateStudyRoomResponse;
 import com.oddok.server.domain.studyroom.dto.StudyRoomDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.springframework.data.domain.Page;
 
 @Mapper
 public interface StudyRoomDtoMapper {

--- a/server/src/test/java/com/oddok/server/domain/studyroom/application/StudyRoomServiceTest.java
+++ b/server/src/test/java/com/oddok/server/domain/studyroom/application/StudyRoomServiceTest.java
@@ -3,8 +3,8 @@ package com.oddok.server.domain.studyroom.application;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willReturn;
 
+import com.oddok.server.common.errors.UserAlreadyJoinedStudyRoom;
 import com.oddok.server.domain.studyroom.dao.HashtagRepository;
 import com.oddok.server.domain.bookmark.dao.ParticipantRepository;
 import com.oddok.server.domain.studyroom.dao.StudyRoomHashtagRepository;
@@ -12,14 +12,18 @@ import com.oddok.server.domain.studyroom.dao.StudyRoomRepository;
 import com.oddok.server.domain.studyroom.dto.StudyRoomDto;
 import com.oddok.server.domain.studyroom.entity.Category;
 import com.oddok.server.domain.studyroom.entity.Hashtag;
+import com.oddok.server.domain.studyroom.entity.Participant;
 import com.oddok.server.domain.studyroom.entity.StudyRoom;
 import com.oddok.server.domain.studyroom.mapper.StudyRoomMapper;
 import com.oddok.server.domain.user.dao.UserRepository;
 import com.oddok.server.domain.user.entity.User;
+
 import java.time.LocalDateTime;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,117 +35,184 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class StudyRoomServiceTest {
 
-  @InjectMocks
-  private StudyRoomService studyRoomService;
+    @InjectMocks
+    private StudyRoomService studyRoomService;
 
-  @Mock
-  private UserRepository userRepository;
-  @Mock
-  private StudyRoomRepository studyRoomRepository;
-  @Mock
-  private HashtagRepository hashtagRepository;
-  @Mock
-  private StudyRoomHashtagRepository studyRoomHashtagRepository;
-  @Mock
-  private ParticipantRepository participantRepository;
+    @Mock
+    private SessionManager sessionManager;
 
-  private final StudyRoomMapper studyRoomMapper = Mappers.getMapper(StudyRoomMapper.class);
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private StudyRoomRepository studyRoomRepository;
+    @Mock
+    private HashtagRepository hashtagRepository;
+    @Mock
+    private StudyRoomHashtagRepository studyRoomHashtagRepository;
+    @Mock
+    private ParticipantRepository participantRepository;
 
+    private final StudyRoomMapper studyRoomMapper = Mappers.getMapper(StudyRoomMapper.class);
 
-  private final Long userId = 1L;
-  private final Long studyRoomId = 1L;
-  private final String newHashtag = "새로운 해시태그";
-  private final String oldHashtag = "기존의 해시태그";
-  private final String removedHashtag = "삭제될 해시태그";
+    private final Long userId = 1L;
+    private final Long studyRoomId = 1L;
+    private final String sessionId = "wss://localhost:4443?sessionId=ses_IJLBwb4IbG&token=tok_KtQQqCkgCbWtHw0e";
+    private final String newHashtag = "새로운 해시태그";
+    private final String oldHashtag = "기존의 해시태그";
+    private final String removedHashtag = "삭제될 해시태그";
 
-  @BeforeEach
-  void setUp() {
-  }
+    private User user;
+    private StudyRoom studyRoom;
 
-
-  @Test
-  void 스터디룸_생성_성공() {
-    //given
-    StudyRoom studyRoom = createStudyRoom();
-    StudyRoomDto studyRoomDto = studyRoomMapper.toDto(studyRoom);
-
-    //when
-    given(studyRoomRepository.save(any(StudyRoom.class))).willReturn(studyRoom);
-    given(userRepository.findById(any())).willReturn(Optional.ofNullable(studyRoom.getUser()));
-    StudyRoomDto newStudyRoomDto = studyRoomService.createStudyRoom(studyRoomDto);
-
-    //then
-    for(String name : newStudyRoomDto.getHashtags()){
-      assertTrue(studyRoomDto.getHashtags().contains(name));
+    @BeforeEach
+    void setUp(){
+        user = createUser();
+        studyRoom = createStudyRoom();
     }
-  }
 
-  @Test
-  void 스터디룸_수정_성공_없는해시태그삭제_새로운해시태그등록() {
-    //given
-    StudyRoom studyRoom = createStudyRoom();
+    @Test
+    void 스터디룸_생성_성공() {
+        //given
+        StudyRoomDto studyRoomDto = studyRoomMapper.toDto(studyRoom);
 
-    Set<String> newHastags = new HashSet<>();
-    newHastags.add(newHashtag);
-    newHastags.add(oldHashtag);
+        //when
+        given(studyRoomRepository.save(any(StudyRoom.class))).willReturn(studyRoom);
+        given(userRepository.findById(any())).willReturn(Optional.ofNullable(studyRoom.getUser()));
+        StudyRoomDto newStudyRoomDto = studyRoomService.createStudyRoom(studyRoomDto);
 
-    given(hashtagRepository.findByName(oldHashtag)).willReturn(
-        Optional.of(new Hashtag(oldHashtag)));
-    given(hashtagRepository.findByName(newHashtag)).willReturn(
-        Optional.of(new Hashtag(newHashtag)));
-    given(studyRoomRepository.findById(studyRoomId)).willReturn(Optional.of(studyRoom));
+        //then
+        for (String name : newStudyRoomDto.getHashtags()) {
+            assertTrue(studyRoomDto.getHashtags().contains(name));
+        }
+    }
 
-    //when
-    StudyRoomDto updateDto = createStudyRoomDto(newHastags);
-    StudyRoomDto updatedStudyRoomDto = studyRoomService.updateStudyRoom(updateDto);
+    @Test
+    void 스터디룸_수정_성공_없는해시태그삭제_새로운해시태그등록() {
+        //given
+        Set<String> newHastags = new HashSet<>();
+        newHastags.add(newHashtag);
+        newHastags.add(oldHashtag);
 
-    //then
-    assertTrue(updatedStudyRoomDto.getHashtags().contains(newHashtag));
-    assertTrue(updatedStudyRoomDto.getHashtags().contains(oldHashtag));
-    assertFalse(updatedStudyRoomDto.getHashtags().contains(removedHashtag));
-    assertEquals(updatedStudyRoomDto.getHashtags().size(), 2);
-  }
+        given(hashtagRepository.findByName(oldHashtag)).willReturn(
+                Optional.of(new Hashtag(oldHashtag)));
+        given(hashtagRepository.findByName(newHashtag)).willReturn(
+                Optional.of(new Hashtag(newHashtag)));
+        given(studyRoomRepository.findById(studyRoomId)).willReturn(Optional.of(studyRoom));
 
-  Set<String> createHastagNames() {
-    Set<String> hashtags = new HashSet<>();
-    hashtags.add(oldHashtag);
-    hashtags.add(removedHashtag);
-    return hashtags;
-  }
+        //when
+        StudyRoomDto updateDto = createStudyRoomDto(newHastags);
+        StudyRoomDto updatedStudyRoomDto = studyRoomService.updateStudyRoom(updateDto);
 
-  StudyRoomDto createStudyRoomDto(Set<String> hashtags) {
-    return StudyRoomDto.builder()
-        .id(studyRoomId)
-        .name("방 제목")
-        .category(Category.SCHOOL)
-        .userId(userId)
-        .sessionId("ws://session@rewrewfr")
-        .image("imageUrl")
-        .isPublic(false)
-        .password("1234")
-        .targetTime(4)
-        .rule("뽀모도로로 진행합니다.")
-        .isMicOn(false)
-        .isCamOn(true)
-        .currentUsers(0)
-        .limitUsers(6)
-        .startAt(LocalDateTime.now())
-        .endAt(LocalDateTime.now().plusDays(5))
-        .hashtags(hashtags)
-        .build();
-  }
+        //then
+        assertTrue(updatedStudyRoomDto.getHashtags().contains(newHashtag));
+        assertTrue(updatedStudyRoomDto.getHashtags().contains(oldHashtag));
+        assertFalse(updatedStudyRoomDto.getHashtags().contains(removedHashtag));
+        assertEquals(updatedStudyRoomDto.getHashtags().size(), 2);
+    }
 
-  User createUser() {
-    return User.builder()
-        .email("parkjh4400@gmail.com")
-        .build();
-  }
 
-  StudyRoom createStudyRoom(){
-    StudyRoomDto studyRoomDto = createStudyRoomDto(createHastagNames());
-    User user = createUser();
-    StudyRoom studyRoom = studyRoomMapper.toEntity(studyRoomDto, user);
-    return studyRoom;
-  }
+    @Test
+    void 스터디룸참여_처음일때_세션생성_참여인원증가_성공() {
+        //given
+        given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
+        given(studyRoomRepository.findById(any())).willReturn(Optional.ofNullable(studyRoom));
+        given(participantRepository.findByUser(any())).willReturn(Optional.empty());
+        given(sessionManager.createSession()).willReturn(sessionId);
+
+        //when
+        studyRoomService.userJoinStudyRoom(userId, studyRoomId);
+
+        //then
+        assert(studyRoom.getSessionId()).equals(sessionId);
+        assert(studyRoom.getCurrentUsers()).equals(1);
+    }
+
+    @Test
+    void 스터디룸참여_사용자가_이미_스터디룸에_참여중이면_예외처리() {
+        //given
+        given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
+        given(studyRoomRepository.findById(any())).willReturn(Optional.ofNullable(studyRoom));
+        given(participantRepository.findByUser(any())).willReturn(Optional.of(new Participant(studyRoom, user)));
+
+        //when,then
+        assertThrows(UserAlreadyJoinedStudyRoom.class, () -> studyRoomService.userJoinStudyRoom(userId, studyRoomId));
+    }
+
+    @Test
+    void 스터디룸나가기_마지막사용자면_세션삭제_참여자수감소() {
+        //given
+        studyRoom.createSession(sessionId);
+        studyRoom.increaseCurrentUsers();
+        given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
+        given(studyRoomRepository.findById(any())).willReturn(Optional.ofNullable(studyRoom));
+        given(participantRepository.findByUser(any())).willReturn(Optional.of(new Participant(studyRoom, user)));
+
+        //when
+        studyRoomService.userLeaveStudyRoom(userId, studyRoomId);
+
+        //then
+        assert(studyRoom.getCurrentUsers()).equals(0);
+        assertNull(studyRoom.getSessionId());
+    }
+
+    @Test
+    void 스터디룸나가기_참여자감소() {
+        //given
+        studyRoom.createSession(sessionId);
+        studyRoom.increaseCurrentUsers();
+        studyRoom.increaseCurrentUsers();
+        given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
+        given(studyRoomRepository.findById(any())).willReturn(Optional.ofNullable(studyRoom));
+        given(participantRepository.findByUser(any())).willReturn(Optional.of(new Participant(studyRoom, user)));
+
+        //when
+        studyRoomService.userLeaveStudyRoom(userId, studyRoomId);
+
+        //then
+        assert(studyRoom.getCurrentUsers()).equals(1);
+        assert(studyRoom.getSessionId()).equals(sessionId);
+    }
+
+    Set<String> createHastagNames() {
+        Set<String> hashtags = new HashSet<>();
+        hashtags.add(oldHashtag);
+        hashtags.add(removedHashtag);
+        return hashtags;
+    }
+
+    StudyRoomDto createStudyRoomDto(Set<String> hashtags) {
+        return StudyRoomDto.builder()
+                .id(studyRoomId)
+                .name("방 제목")
+                .category(Category.SCHOOL)
+                .userId(userId)
+                .image("imageUrl")
+                .isPublic(false)
+                .password("1234")
+                .targetTime(4)
+                .rule("뽀모도로로 진행합니다.")
+                .isMicOn(false)
+                .isCamOn(true)
+                .currentUsers(0)
+                .limitUsers(6)
+                .startAt(LocalDateTime.now())
+                .endAt(LocalDateTime.now().plusDays(5))
+                .hashtags(hashtags)
+                .build();
+    }
+
+
+    User createUser() {
+        return User.builder()
+                .email("parkjh4400@gmail.com")
+                .build();
+    }
+
+    StudyRoom createStudyRoom() {
+        StudyRoomDto studyRoomDto = createStudyRoomDto(createHastagNames());
+        User user = createUser();
+        return studyRoomMapper.toEntity(studyRoomDto, user);
+    }
+
 
 }


### PR DESCRIPTION
1. 스터디룸 서비스의 생성/참여/해시태그수정/나가기 테스트 코드 작성
2. 스터디룸 생성 request & 스터디룸 엔티티 생성자에서 sessionId 컬럼 제외
3. 세션 삭제를 currentUsers  체크 조건문 안으로 이동
