### PR TITLE
[BE] 스터디룸 이름 검색에 대한 인기 해시태그 상위 15개 리스트를 가져오는 API 구현

### DIFF
--- a/server/src/main/java/com/oddok/server/common/component/BatchScheduler.java
+++ b/server/src/main/java/com/oddok/server/common/component/BatchScheduler.java
@@ -1,6 +1,8 @@
 package com.oddok.server.common.component;
 
 import com.oddok.server.common.config.BatchConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersInvalidException;
@@ -15,12 +17,12 @@ import org.springframework.stereotype.Component;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
+@RequiredArgsConstructor
 @Component
 public class BatchScheduler {
 
-    @Autowired
     private JobLauncher jobLauncher;
-    @Autowired
     private BatchConfig batchConfig;
 
     @Scheduled(cron = "0 0 9 * * 7") // 일요일 아침 9시 정각 0초
@@ -33,8 +35,8 @@ public class BatchScheduler {
         try {
             jobLauncher.run(batchConfig.job(), jobParameters);
         } catch (JobExecutionAlreadyRunningException | JobInstanceAlreadyCompleteException
-            | JobParametersInvalidException | JobRestartException e) {
-            System.out.println(e.getMessage());
+                | JobParametersInvalidException | JobRestartException e) {
+            log.error("batch job error = {}", e.getMessage());
         }
     }
 }

--- a/server/src/main/java/com/oddok/server/common/errors/OpenviduServerException.java
+++ b/server/src/main/java/com/oddok/server/common/errors/OpenviduServerException.java
@@ -1,7 +1,11 @@
 package com.oddok.server.common.errors;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class OpenviduServerException extends RuntimeException {
     public OpenviduServerException(String message, Throwable cause) {
         super(message, cause);
+        log.error("openvidu server error message = {}, cause = {]", message, cause);
     }
 }

--- a/server/src/main/java/com/oddok/server/domain/studyroom/api/HashtagController.java
+++ b/server/src/main/java/com/oddok/server/domain/studyroom/api/HashtagController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -17,9 +18,14 @@ public class HashtagController {
 
     private final HashtagService hashtagService;
 
+    /**
+     * 스터디룸에서 가장 많이 쓰인 해시태그를 조회합니다.
+     * @param name 스터디룸 방 이름으로 검색 시 해당 검색 결과 내에서 가장 많이 쓰인 해시태그를 조회합니다.
+     * @return 해시태그 이름 리스트
+     */
     @GetMapping("/popular")
-    public ResponseEntity<GetPopularHashtagsResponse> getPopularHashtags(){
-        GetPopularHashtagsResponse response = new GetPopularHashtagsResponse(hashtagService.findTop15Hashtags());
+    public ResponseEntity<GetPopularHashtagsResponse> getPopularHashtags(@RequestParam(required = false) String name){
+        GetPopularHashtagsResponse response = new GetPopularHashtagsResponse(hashtagService.findTop15Hashtags(name));
         return ResponseEntity.ok(response);
     }
 

--- a/server/src/main/java/com/oddok/server/domain/studyroom/application/HashtagService.java
+++ b/server/src/main/java/com/oddok/server/domain/studyroom/application/HashtagService.java
@@ -14,8 +14,8 @@ public class HashtagService {
 
     private final HashtagQueryRepository hashtagQueryRepository;
 
-    public List<String> findTop15Hashtags() {
-        return hashtagQueryRepository.findTop15Hashtags();
+    public List<String> findTop15Hashtags(String name) {
+        return hashtagQueryRepository.findTop15Hashtags(name);
     }
 
 }

--- a/server/src/main/java/com/oddok/server/domain/studyroom/application/SessionManager.java
+++ b/server/src/main/java/com/oddok/server/domain/studyroom/application/SessionManager.java
@@ -4,9 +4,11 @@ import com.oddok.server.common.errors.OpenviduServerException;
 import com.oddok.server.common.errors.SessionNotFoundException;
 import io.openvidu.java.client.*;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class SessionManager {
 
@@ -28,10 +30,9 @@ public class SessionManager {
         SessionProperties properties = new SessionProperties.Builder().build();
         try {
             Session session = openVidu.createSession(properties);
-            System.out.println("💘 세션 생성 : " + session);
+            log.info("session = {}", session);
             return session.getSessionId();
         } catch (OpenViduJavaClientException | OpenViduHttpException e) {
-            e.printStackTrace();
             throw new OpenviduServerException(e.getMessage(), e.getCause());
         }
     }
@@ -86,7 +87,7 @@ public class SessionManager {
         try {
             session.close();
         } catch (OpenViduJavaClientException | OpenViduHttpException e) {
-            e.printStackTrace();
+            throw new OpenviduServerException(e.getMessage(), e.getCause());
         }
     }
 

--- a/server/src/main/java/com/oddok/server/domain/studyroom/application/StudyRoomService.java
+++ b/server/src/main/java/com/oddok/server/domain/studyroom/application/StudyRoomService.java
@@ -40,7 +40,7 @@ public class StudyRoomService {
     @Transactional
     public StudyRoomDto createStudyRoom(StudyRoomDto studyRoomDto) {
         User user = findUser(studyRoomDto.getUserId());
-        if (studyRoomRepository.findByUser(user).isPresent()) { // 사용자는 하나의 스터디룸만 개설할 수 있습니다.
+        if (studyRoomRepository.existsByUser(user)) { // 사용자는 하나의 스터디룸만 개설할 수 있습니다.
             throw new UserAlreadyPublishStudyRoomException(user.getId());
         }
         StudyRoom studyRoom = studyRoomMapper.toEntity(studyRoomDto, user);
@@ -100,7 +100,7 @@ public class StudyRoomService {
     @Transactional
     public void deleteStudyRoom(Long id) {
         StudyRoom studyRoom = findStudyRoom(id);
-        if (studyRoom.getSessionId() == null) {
+        if (studyRoom.getSessionId() != null) { // 세션이 살아있으면 세션 삭제
             sessionManager.deleteSession(studyRoom.getSessionId());
         }
         studyRoomRepository.delete(studyRoom);

--- a/server/src/main/java/com/oddok/server/domain/studyroom/dao/StudyRoomRepository.java
+++ b/server/src/main/java/com/oddok/server/domain/studyroom/dao/StudyRoomRepository.java
@@ -5,10 +5,10 @@ import com.oddok.server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
 import java.util.Optional;
 
 @Repository
 public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
     Optional<StudyRoom> findByUser(User user);
+    boolean existsByUser(User user);
 }

--- a/server/src/main/java/com/oddok/server/domain/studyroom/dao/impl/HashtagQueryRepositoryImpl.java
+++ b/server/src/main/java/com/oddok/server/domain/studyroom/dao/impl/HashtagQueryRepositoryImpl.java
@@ -1,9 +1,12 @@
 package com.oddok.server.domain.studyroom.dao.impl;
 
 import static com.oddok.server.domain.studyroom.entity.QHashtag.hashtag;
+import static com.oddok.server.domain.studyroom.entity.QStudyRoom.studyRoom;
 import static com.oddok.server.domain.studyroom.entity.QStudyRoomHashtag.studyRoomHashtag;
 
 import com.oddok.server.domain.studyroom.dao.querydsl.HashtagQueryRepository;
+import com.oddok.server.domain.studyroom.entity.Category;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -16,15 +19,23 @@ public class HashtagQueryRepositoryImpl implements HashtagQueryRepository {
 
   private final JPAQueryFactory queryFactory;
 
-  public List<String> findTop15Hashtags(){
+  public List<String> findTop15Hashtags(String name){
     JPAQuery<String> query = queryFactory.select(hashtag.name)
             .from(hashtag)
             .join(studyRoomHashtag)
             .on(hashtag.eq(studyRoomHashtag.hashtag))
+            .where(containsName(name))
             .groupBy(hashtag)
             .orderBy(hashtag.count().desc())
             .limit(15);
     return query.fetch();
   };
+
+  private BooleanExpression containsName(String name) {
+    if (name == null || name.isBlank()) {
+      return null;
+    }
+    return studyRoomHashtag.studyRoom.name.contains(name);
+  }
 
 }

--- a/server/src/main/java/com/oddok/server/domain/studyroom/dao/impl/StudyRoomQueryRepositoryImpl.java
+++ b/server/src/main/java/com/oddok/server/domain/studyroom/dao/impl/StudyRoomQueryRepositoryImpl.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.tomcat.jni.Local;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.stereotype.Repository;

--- a/server/src/main/java/com/oddok/server/domain/studyroom/dao/querydsl/HashtagQueryRepository.java
+++ b/server/src/main/java/com/oddok/server/domain/studyroom/dao/querydsl/HashtagQueryRepository.java
@@ -3,5 +3,5 @@ package com.oddok.server.domain.studyroom.dao.querydsl;
 import java.util.List;
 
 public interface HashtagQueryRepository {
-  List<String> findTop15Hashtags();
+  List<String> findTop15Hashtags(String name);
 }

--- a/server/src/main/java/com/oddok/server/domain/studyroom/entity/StudyRoom.java
+++ b/server/src/main/java/com/oddok/server/domain/studyroom/entity/StudyRoom.java
@@ -21,7 +21,7 @@ public class StudyRoom {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false, length = 255)
+    @Column(nullable = false, length = 255)
     private String name;
 
     private Category category;


### PR DESCRIPTION
 스터디룸 '방 제목' 으로 검색 하는 경우
 검색 결과에 대한 인기 해시태그 상위 15개 리스트를 가져오는 API
- [기존] /hashtag/popular : 전체 스터디룸에 대한 인기 해시태그 상위 15개 리스트
- [추가] /hashtag/popular?name=방제목

issue: #85