### PR TITLE
[FE] 공통 레이아웃 컴포넌트 제작 및 CSS 수정

### DIFF
--- a/client/src/components/commons/UserCount/UserCount.jsx
+++ b/client/src/components/commons/UserCount/UserCount.jsx
@@ -2,21 +2,19 @@ import React from "react";
 import { Plus, Person } from "@icons";
 import styles from "./UserCount.module.css";
 
-function UserCount({ number, isTotalUser, isBookmarkUser }) {
+function UserCount({ number }) {
   const users = [];
-  const displayType = isTotalUser || isBookmarkUser ? styles.big : styles.small;
-
   for (let i = 0; i < number; i += 1) {
     // 참여자 6명 이상일때 옆에 + 하나만 추가
     if (i > 4 && i <= 5) {
       users.push(
-        <div className={`${styles.plus} ${displayType}`}>
+        <div className={styles.plus}>
           <Plus />
         </div>,
       );
     } else if (i <= 4) {
       users.push(
-        <div className={displayType}>
+        <div className={styles.person}>
           <Person />
         </div>,
       );

--- a/client/src/components/commons/UserCount/UserCount.module.css
+++ b/client/src/components/commons/UserCount/UserCount.module.css
@@ -1,4 +1,4 @@
-.big {
+/* .big {
   width: 2em;
   height: 2em;
   margin-right: 0.5em;
@@ -18,10 +18,24 @@
 .plus.small {
   width: 0.7em;
   height: 1.3em;
-}
+} */
 
 .count {
   display: flex;
+  flex-direction: row;
+  align-items: center;
   color: var(--primary);
-  gap: 8px;
+  gap: inherit;
+  height: inherit;
+}
+
+.person {
+  height: 100%;
+}
+
+.plus {
+  height: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/client/src/components/home/StudyRoomCard/StudyRoomCard.jsx
+++ b/client/src/components/home/StudyRoomCard/StudyRoomCard.jsx
@@ -50,7 +50,9 @@ function StudyRoomCard({ roomData, showBookmark }) {
             </button>
           )}
           <div className={styles.user_count}>
-            <UserCount number={roomData.currentUsers} />
+            <div className={styles.count_icon}>
+              <UserCount number={roomData.currentUsers} />
+            </div>
             <span>/ {roomData.limitUsers}</span>
           </div>
         </div>

--- a/client/src/components/home/StudyRoomCard/StudyRoomCard.module.css
+++ b/client/src/components/home/StudyRoomCard/StudyRoomCard.module.css
@@ -27,6 +27,11 @@
   align-items: baseline;
 }
 
+.count_icon {
+  height: 16px;
+  gap: 6px;
+}
+
 .user_count span {
   font-size: 0.75rem;
   color: var(--gray300);

--- a/client/src/components/home/TotalParticipant/TotalParticipant.jsx
+++ b/client/src/components/home/TotalParticipant/TotalParticipant.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { UserCount } from "@components/commons";
 import { getTotalParticipant } from "@api/participant-api";
+import { Plus } from "@icons";
 import styles from "./TotalParticipant.module.css";
 
 function TotalParticipant() {
@@ -15,11 +16,12 @@ function TotalParticipant() {
   }, []);
 
   // 버튼 누르면 로그인 페이지 이동
-
   return (
     <div className={styles.participant}>
       <div className={styles.count_box}>
-        <UserCount number={totalParticipant} isTotalUser={isTotalUser} />
+        <div className={styles.count_icon}>
+          <UserCount number={totalParticipant} />
+        </div>
         <p className={styles.count}>{totalParticipant}명이 ODDOK에서 공부 중이에요</p>
       </div>
       <div className={styles.button_box}>

--- a/client/src/components/home/TotalParticipant/TotalParticipant.module.css
+++ b/client/src/components/home/TotalParticipant/TotalParticipant.module.css
@@ -1,10 +1,17 @@
 .participant {
   display: flex;
+  align-items: flex-end;
   color: white;
 }
 
 .count_box {
   flex: 1 1 70%;
+}
+
+.count_icon {
+  height: 48px;
+  gap: 12px;
+  display: flex;
 }
 
 .count {

--- a/client/src/components/home/TotalParticipant/TotalParticipant.module.css
+++ b/client/src/components/home/TotalParticipant/TotalParticipant.module.css
@@ -1,18 +1,16 @@
 .participant {
   display: flex;
-  padding: 2em 11.5em;
   color: white;
 }
 
 .count_box {
   flex: 1 1 70%;
-  padding-left: 1em;
 }
 
 .count {
   margin: 0;
   margin-top: 0.5em;
-  font-size: 1.5rem;
+  font-size: 1.8rem;
   font-weight: 600;
 }
 
@@ -24,8 +22,8 @@
 }
 
 .button {
-  padding: 0.7em 4.5em;
-  font-size: 0.9rem;
+  padding: 0.7em 4.1em;
+  font-size: 1rem;
   font-weight: 700;
   border-radius: 4px;
   color: var(--gray950);

--- a/client/src/components/home/bookmark/Bookmark.jsx
+++ b/client/src/components/home/bookmark/Bookmark.jsx
@@ -59,7 +59,9 @@ function Bookmark({ showBookmark }) {
         <div>
           <div className={styles.count_info}>
             <div className={styles.count_box}>
-              <UserCount number={bookmark.currentUsers} isBookmarkUser={isBookmarkUser} />
+              <div className={styles.count_icon}>
+                <UserCount number={bookmark.currentUsers} />
+              </div>
               <p className={styles.count}>스터디원 {bookmark.currentUsers}명이 공부 중이에요</p>
             </div>
             <div className={styles.button_box}>

--- a/client/src/components/home/bookmark/bookmark.module.css
+++ b/client/src/components/home/bookmark/bookmark.module.css
@@ -10,7 +10,6 @@
 
 .count_info {
   display: flex;
-  padding: 2em 12em;
   background-color: var(--gray950);
 }
 
@@ -19,9 +18,14 @@
   padding-left: 1em;
 }
 
+.count_icon {
+  height: 44px;
+  gap: 12px;
+}
+
 .count {
   margin-top: 0.5em;
-  font-size: 1.5rem;
+  font-size: 1.8rem;
   font-weight: 600;
 }
 
@@ -33,7 +37,7 @@
 }
 
 .button {
-  padding: 0.7em 6em;
+  padding: 1em 6em;
   font-weight: 700;
   border-radius: 4px;
   color: var(--gray950);
@@ -42,25 +46,24 @@
 
 .info {
   display: flex;
-  align-items: center;
-  padding: 1em 12em;
   background-color: black;
+  padding: 1em;
+  margin: 1em 0;
 }
 
 .detail {
-  flex: 1 1 75%;
+  flex: 1 1 70%;
   display: flex;
-  margin: 1em;
+  gap: 1em;
 }
 
 .user_list {
-  flex: 1 1 25%;
+  flex: 1 1 30%;
   display: flex;
   flex-direction: column;
 }
 
 .thumbnail {
-  margin-right: 1em;
   background-color: var(--gray900);
 }
 

--- a/client/src/components/home/footer/footer.module.css
+++ b/client/src/components/home/footer/footer.module.css
@@ -1,5 +1,5 @@
 .footer {
-  margin-top: 1em;
+  margin-top: auto;
   background-color: black;
   color: var(--gray300);
 }

--- a/client/src/components/layout/Layout.jsx
+++ b/client/src/components/layout/Layout.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Header, Footer } from "@components/home";
+import styles from "./Layout.module.css";
+
+function Layout({ children }) {
+  return (
+    <div className={styles.wrap}>
+      <Header />
+      <div className={styles.inner}>{children}</div>
+      <Footer />
+    </div>
+  );
+}
+
+export default Layout;

--- a/client/src/components/layout/Layout.module.css
+++ b/client/src/components/layout/Layout.module.css
@@ -1,0 +1,13 @@
+.wrap {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 80px;
+}
+
+.inner {
+  width: 75%;
+  max-width: 1320px;
+  margin: 0 auto;
+}

--- a/client/src/components/layout/Layout.module.css
+++ b/client/src/components/layout/Layout.module.css
@@ -10,4 +10,5 @@
   width: 75%;
   max-width: 1320px;
   margin: 0 auto;
+  color: white;
 }

--- a/client/src/components/layout/index.js
+++ b/client/src/components/layout/index.js
@@ -1,0 +1,1 @@
+export { default as Layout } from "./Layout";

--- a/client/src/components/search/index.js
+++ b/client/src/components/search/index.js
@@ -1,0 +1,2 @@
+export { default as SearchBrowse } from "./SearchBrowse/SearchBrowse";
+export { default as SearchResult } from "./SearchResult/SearchResult";

--- a/client/src/pages/MainHome/MainHome.jsx
+++ b/client/src/pages/MainHome/MainHome.jsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useSetRecoilState } from "recoil";
 import { bookmarkState } from "@recoil/bookmark-state";
 import { getBookmark } from "@api/bookmark-api";
 import { getTestUser } from "@api/getTestUser";
-import { Bookmark, Footer, Header, StudyRoomList, TotalParticipant } from "@components/home";
+import { Layout } from "@components/layout";
+import { Bookmark, StudyRoomList } from "@components/home";
 import styles from "./MainHome.module.css";
 
 function MainHome() {
@@ -26,15 +27,15 @@ function MainHome() {
   // 전체 참여자수 컴포넌트 추가
 
   return (
-    <div className={styles.home}>
-      <Header />
-      <Bookmark showBookmark={showBookmark} />
-      <section className={styles.studyroom_list}>
-        <h2>STUDY ROOM</h2>
-        <StudyRoomList showBookmark={showBookmark} />
-      </section>
-      <Footer />
-    </div>
+    <Layout>
+      <main className={styles.main}>
+        <Bookmark showBookmark={showBookmark} />
+        <section className={styles.studyroom_list}>
+          <h2>STUDY ROOM</h2>
+          <StudyRoomList showBookmark={showBookmark} />
+        </section>
+      </main>
+    </Layout>
   );
 }
 

--- a/client/src/pages/MainHome/MainHome.module.css
+++ b/client/src/pages/MainHome/MainHome.module.css
@@ -1,7 +1,7 @@
-.studyroom_list {
-  width: 74%;
-  margin: 5rem auto;
-  max-width: 1296px;
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 60px;
 }
 .studyroom_list h2 {
   color: white;

--- a/client/src/pages/MainHome/MainHome.module.css
+++ b/client/src/pages/MainHome/MainHome.module.css
@@ -4,7 +4,6 @@
   gap: 60px;
 }
 .studyroom_list h2 {
-  color: white;
   font-size: 1.5rem;
   font-weight: 600;
   margin-bottom: 18px;

--- a/client/src/pages/MyPage/MyPage.jsx
+++ b/client/src/pages/MyPage/MyPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Header, Footer } from "@components/home";
+import { Layout } from "@components/layout";
 import { SideNavBar, DatePicker, TimeTable, TimeRecordList, MyRoom } from "@components/mypage";
 import { Textarea } from "@components/commons";
 import { getProfile, getTimeRecordList, getMyRoom } from "@api/mypage-api";
@@ -42,8 +42,7 @@ function MyPage() {
   }, [selectedDate]);
 
   return (
-    <div>
-      <Header />
+    <Layout>
       <div className={styles.mypage}>
         <aside className={styles.side_nav_bar}>
           <SideNavBar />
@@ -148,8 +147,7 @@ function MyPage() {
           </section>
         </div>
       </div>
-      <Footer />
-    </div>
+    </Layout>
   );
 }
 

--- a/client/src/pages/MyPage/MyPage.module.css
+++ b/client/src/pages/MyPage/MyPage.module.css
@@ -1,9 +1,5 @@
 .mypage {
-  color: white;
-  max-width: 1140px;
   display: flex;
-  width: 75%;
-  margin: 70px auto;
   gap: 90px;
 }
 

--- a/client/src/pages/search/search.jsx
+++ b/client/src/pages/search/search.jsx
@@ -1,13 +1,12 @@
 /* eslint-disable react/jsx-boolean-value */
 import React, { useState, useRef, useEffect } from "react";
 import { useHistory } from "react-router-dom";
+import { Layout } from "@components/layout";
 import { Input } from "@components/commons";
-import { Header } from "@components/home";
-import SearchBrowse from "@components/search/SearchBrowse/SearchBrowse";
-import SearchResult from "@components/search/SearchResult/SearchResult";
+import { SearchBrowse, SearchResult } from "@components/search";
 import styles from "./Search.module.css";
 
-function Search({ location }) {
+function Search() {
   const history = useHistory();
   const titleRef = useRef();
   const [searched, setSearched] = useState({ title: undefined, hashtag: undefined });
@@ -49,25 +48,22 @@ function Search({ location }) {
   }, [history, searched]);
 
   return (
-    <div>
-      <Header />
-      <div className={styles.container}>
-        <div className={styles.title_input}>
-          <form onSubmit={searchTitleHandler}>
-            <Input ref={titleRef} />
-          </form>
-        </div>
-        {!location.search ? (
-          <SearchBrowse
-            searchHashtagHandler={searchHashtagHandler}
-            searchKeywordHandler={searchKeywordHandler}
-            setSearched={setSearched}
-          />
-        ) : (
-          <SearchResult />
-        )}
+    <Layout>
+      <div className={styles.title_input}>
+        <form onSubmit={searchTitleHandler}>
+          <Input ref={titleRef} />
+        </form>
       </div>
-    </div>
+      {!history.location.search ? (
+        <SearchBrowse
+          searchHashtagHandler={searchHashtagHandler}
+          searchKeywordHandler={searchKeywordHandler}
+          setSearched={setSearched}
+        />
+      ) : (
+        <SearchResult />
+      )}
+    </Layout>
   );
 }
 

--- a/client/src/pages/search/search.module.css
+++ b/client/src/pages/search/search.module.css
@@ -1,9 +1,3 @@
-.container {
-  width: 70%;
-  margin: 90px auto;
-  color: white;
-}
-
 .title_input {
   font-size: 0.75rem;
   margin-bottom: 70px;


### PR DESCRIPTION
헤더랑 풋터 매번 임포트하고 너비도 제각각이길래 레이아웃 공통으로 적용하려고 따로 컴포넌트로 뺐습니다!
유저카운트에서 prop으로 사용 용도 판별해서 크기 지정하던거 상위 태그에서 크기랑 gap 지정할 수 있도록 inherit으로 바꿨는데 괜찮은지 확인 부탁해yo
아 그리고 메인홈에서 상위에서 너비를 지정해버리니까 북마크 부분에 검정색 배경 양 옆이 잘렸는데... 이건 아직 해결 못했습니다...😳


