### PR TITLE
[BE] 로그인 에러 처리 핸들러 추가

### DIFF
--- a/server/src/main/java/com/oddok/server/common/ControllerErrorAdvice.java
+++ b/server/src/main/java/com/oddok/server/common/ControllerErrorAdvice.java
@@ -124,4 +124,10 @@ public class ControllerErrorAdvice {
     public ErrorResponse handlerTokenValidFailedException() {
         return new ErrorResponse("토큰이 유효하지 않습니다.");
     }
+
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ExceptionHandler(AccessTokenException.class)
+    public ErrorResponse handlerCustomAccessDeniedException() {
+        return new ErrorResponse("로그인이 되어 있지 않습니다.");
+    }
 }

--- a/server/src/main/java/com/oddok/server/common/config/SecurityConfig.java
+++ b/server/src/main/java/com/oddok/server/common/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.oddok.server.common.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oddok.server.common.handler.CustomAccessDeniedHandler;
+import com.oddok.server.common.handler.CustomAuthenticationEntryPoint;
 import com.oddok.server.common.jwt.JwtAuthenticationFilter;
 import com.oddok.server.common.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
 
+        CustomAuthenticationEntryPoint customAuthenticationEntryPoint = new CustomAuthenticationEntryPoint();
+        CustomAccessDeniedHandler customAccessDeniedHandler = new CustomAccessDeniedHandler();
+
         http.httpBasic().disable()
                 .authorizeRequests()
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
@@ -45,6 +50,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.OK))
                 .invalidateHttpSession(true)
                 .deleteCookies("refreshToken")
+                .and()
+                .exceptionHandling()
+                .authenticationEntryPoint(customAuthenticationEntryPoint)
+                .accessDeniedHandler(customAccessDeniedHandler)
                 .and()
                 .headers()
                 .frameOptions().disable()

--- a/server/src/main/java/com/oddok/server/common/errors/AccessTokenException.java
+++ b/server/src/main/java/com/oddok/server/common/errors/AccessTokenException.java
@@ -1,0 +1,7 @@
+package com.oddok.server.common.errors;
+
+public class AccessTokenException extends RuntimeException {
+    public AccessTokenException() {
+        super("로그인이 되어 있지 않습니다.");
+    }
+}

--- a/server/src/main/java/com/oddok/server/common/handler/CustomAccessDeniedHandler.java
+++ b/server/src/main/java/com/oddok/server/common/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,39 @@
+package com.oddok.server.common.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oddok.server.common.ErrorResponse;
+import com.oddok.server.common.errors.AccessTokenException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+
+@Component
+@Slf4j
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    ErrorResponse errorResponse = new ErrorResponse(new AccessTokenException().getMessage());
+
+    @Override
+    public void handle(HttpServletRequest httpServletRequest,
+                       HttpServletResponse httpServletResponse,
+                       AccessDeniedException e) throws IOException {
+
+        log.error("로그인이 되어 있지 않습니다.");
+
+        httpServletResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        httpServletResponse.setStatus(HttpStatus.FORBIDDEN.value());
+        try (OutputStream os = httpServletResponse.getOutputStream()) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.writeValue(os, errorResponse);
+            os.flush();
+        }
+    }
+}

--- a/server/src/main/java/com/oddok/server/common/handler/CustomAuthenticationEntryPoint.java
+++ b/server/src/main/java/com/oddok/server/common/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package com.oddok.server.common.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oddok.server.common.ErrorResponse;
+import com.oddok.server.common.errors.AccessTokenException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+
+@Component
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    ErrorResponse errorResponse = new ErrorResponse(new AccessTokenException().getMessage());
+
+    @Override
+    public void commence(HttpServletRequest httpServletRequest,
+                         HttpServletResponse httpServletResponse,
+                         AuthenticationException e) throws IOException {
+
+        log.error("로그인이 되어 있지 않습니다.");
+
+        httpServletResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        httpServletResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
+        try (OutputStream os = httpServletResponse.getOutputStream()) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.writeValue(os, errorResponse);
+            os.flush();
+        }
+    }
+}


### PR DESCRIPTION
handler를 override 해야해서 throw 쓰게 되면 500 에러 또는 메시지가 안 뜨게 됨.
response에 값을 넣든, objectMapper에 값을 넣어서 보내주든 에러처리처럼 하는 게 아니라 값을 보내줘야 함.