### PR TITLE
[BE] user 정보 수정

### DIFF
--- a/server/src/main/java/com/oddok/server/common/errors/SocialDataNotFoundException.java
+++ b/server/src/main/java/com/oddok/server/common/errors/SocialDataNotFoundException.java
@@ -1,7 +1,0 @@
-package com.oddok.server.common.errors;
-
-public class SocialDataNotFoundException extends RuntimeException {
-    public SocialDataNotFoundException() {
-        super("Social Data not found");
-    }
-}

--- a/server/src/main/java/com/oddok/server/domain/user/application/AuthService.java
+++ b/server/src/main/java/com/oddok/server/domain/user/application/AuthService.java
@@ -1,6 +1,5 @@
 package com.oddok.server.domain.user.application;
 
-import com.oddok.server.common.errors.TokenValidFailedException;
 import com.oddok.server.common.errors.UserNotFoundException;
 import com.oddok.server.common.jwt.JwtTokenProvider;
 import com.oddok.server.domain.user.client.ClientKakao;
@@ -26,13 +25,13 @@ public class AuthService {
     public TokensDto login(String kakaoAccessToken) {
         User kakaoUser = clientKakao.getUserData(kakaoAccessToken);
 
-        String userEmail = kakaoUser.getEmail();
+        String userId = kakaoUser.getUserId();
 
-        User user = userRepository.findByEmail(userEmail).orElseGet(() -> userRepository.save(kakaoUser));
+        User user = userRepository.findByUserId(userId).orElseGet(() -> userRepository.save(kakaoUser));
 
-        String accessToken = authTokenProvider.createAccessToken(user.getId().toString(), userEmail, user.getRole());
+        String accessToken = authTokenProvider.createAccessToken(user.getId().toString(), userId, user.getRole());
 
-        user.updateRefreshToken(authTokenProvider.createRefreshToken(user.getId().toString(), userEmail, user.getRole()));
+        user.updateRefreshToken(authTokenProvider.createRefreshToken(user.getId().toString(), userId, user.getRole()));
 
         return TokensDto.builder()
                 .accessToken(accessToken)
@@ -46,7 +45,7 @@ public class AuthService {
 
         User user = findUser(Long.parseLong(refreshUserId));
 
-        String accessToken = authTokenProvider.createAccessToken(user.getId().toString(), user.getEmail(), user.getRole());
+        String accessToken = authTokenProvider.createAccessToken(user.getId().toString(), user.getUserId(), user.getRole());
 
         return TokenDto.builder()
                 .token(accessToken)

--- a/server/src/main/java/com/oddok/server/domain/user/application/UserService.java
+++ b/server/src/main/java/com/oddok/server/domain/user/application/UserService.java
@@ -36,19 +36,19 @@ public class UserService {
     public TokensDto createUser() {
         User maker1 = new User("maker@kakao.com", "maker", Role.USER);
         User savedUser = userRepository.save(maker1);
-        savedUser.updateRefreshToken(authTokenProvider.createRefreshToken(savedUser.getId().toString(), savedUser.getEmail(), savedUser.getRole()));
-        userRepository.save(new User("user1@kakao.com", "user1", Role.USER));
-        userRepository.save(new User("user2@kakao.com", "user2", Role.USER));
-        userRepository.save(new User("user3@kakao.com", "user3", Role.USER));
-        userRepository.save(new User("user4@kakao.com", "user4", Role.USER));
-        userRepository.save(new User("user5@kakao.com", "user5", Role.USER));
-        userRepository.save(new User("user6@kakao.com", "user6", Role.USER));
-        userRepository.save(new User("user7@kakao.com", "user7", Role.USER));
-        userRepository.save(new User("user8@kakao.com", "user8", Role.USER));
-        userRepository.save(new User("user9@kakao.com", "user9", Role.USER));
+        savedUser.updateRefreshToken(authTokenProvider.createRefreshToken(savedUser.getId().toString(), savedUser.getUserId(), savedUser.getRole()));
+        userRepository.save(new User("user1", "user1", Role.USER));
+        userRepository.save(new User("user2", "user2", Role.USER));
+        userRepository.save(new User("user3", "user3", Role.USER));
+        userRepository.save(new User("user4", "user4", Role.USER));
+        userRepository.save(new User("user5", "user5", Role.USER));
+        userRepository.save(new User("user6", "user6", Role.USER));
+        userRepository.save(new User("user7", "user7", Role.USER));
+        userRepository.save(new User("user8", "user8", Role.USER));
+        userRepository.save(new User("user9", "user9", Role.USER));
 
         return TokensDto.builder()
-                .accessToken(authTokenProvider.createAccessToken(savedUser.getId().toString(), savedUser.getEmail(), savedUser.getRole()))
+                .accessToken(authTokenProvider.createAccessToken(savedUser.getId().toString(), savedUser.getUserId(), savedUser.getRole()))
                 .refreshToken(savedUser.getRefreshToken())
                 .build();
     }

--- a/server/src/main/java/com/oddok/server/domain/user/client/ClientKakao.java
+++ b/server/src/main/java/com/oddok/server/domain/user/client/ClientKakao.java
@@ -1,6 +1,5 @@
 package com.oddok.server.domain.user.client;
 
-import com.oddok.server.common.errors.SocialDataNotFoundException;
 import com.oddok.server.domain.user.dto.KakaoUserDto;
 import com.oddok.server.domain.user.entity.Role;
 import com.oddok.server.domain.user.entity.User;
@@ -22,10 +21,8 @@ public class ClientKakao {
                 .bodyToMono(KakaoUserDto.class)
                 .block();
 
-        if (userData.getKakaoAccount().getEmail().isEmpty()) throw new SocialDataNotFoundException();
-
         return User.builder()
-                .email(userData.getKakaoAccount().getEmail())
+                .userId(userData.getId().toString())
                 .nickname(userData.getProperties().getNickname())
                 .role(Role.USER)
                 .build();

--- a/server/src/main/java/com/oddok/server/domain/user/dao/UserRepository.java
+++ b/server/src/main/java/com/oddok/server/domain/user/dao/UserRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
+    Optional<User> findByUserId(String userId);
 }

--- a/server/src/main/java/com/oddok/server/domain/user/dto/KakaoUserDto.java
+++ b/server/src/main/java/com/oddok/server/domain/user/dto/KakaoUserDto.java
@@ -10,29 +10,19 @@ import lombok.*;
 public class KakaoUserDto {
     private final Long id;
     private final Properties properties;
-    private final KakaoAccount kakaoAccount;
 
     @JsonCreator
     public KakaoUserDto(
             @JsonProperty(value = "id") Long id,
-            @JsonProperty(value = "properties") Properties properties,
-            @JsonProperty(value = "kakao_account") KakaoAccount kakaoAccount) {
+            @JsonProperty(value = "properties") Properties properties) {
         this.id = id;
         this.properties = properties;
-        this.kakaoAccount = kakaoAccount;
     }
 
     @Data
     @NoArgsConstructor
     public static class Properties {
         private String nickname;
-    }
-
-    @Data
-    @NoArgsConstructor
-    public static class KakaoAccount {
-        private String email;
-        private String gender;
     }
 
 }

--- a/server/src/main/java/com/oddok/server/domain/user/dto/UserDto.java
+++ b/server/src/main/java/com/oddok/server/domain/user/dto/UserDto.java
@@ -7,14 +7,14 @@ import lombok.Getter;
 public class UserDto {
     private final Long id;
 
-    private final String email;
+    private final String userId;
 
     private final String nickname;
 
     @Builder
-    public UserDto (Long id, String email, String nickname) {
+    public UserDto (Long id, String userId, String nickname) {
         this.id = id;
-        this.email = email;
+        this.userId = userId;
         this.nickname = nickname;
     }
 }

--- a/server/src/main/java/com/oddok/server/domain/user/entity/User.java
+++ b/server/src/main/java/com/oddok/server/domain/user/entity/User.java
@@ -19,7 +19,7 @@ public class User {
     private Long id;
 
     @Column(unique = true, nullable = false, length = 255)
-    private String email;
+    private String userId;
 
     @Column(length = 8)
     private String nickname;
@@ -40,8 +40,8 @@ public class User {
     private LocalDateTime updateAt;
 
     @Builder
-    public User(String email, String nickname, Role role) {
-        this.email = email;
+    public User(String userId, String nickname, Role role) {
+        this.userId = userId;
         this.nickname = nickname;
         this.role = role ;
         this.createAt = LocalDateTime.now();
@@ -50,7 +50,7 @@ public class User {
 
     public User(Claims claims) {
         this.id = Long.valueOf(claims.get("userId").toString());
-        this.email = claims.get("userId").toString();
+        this.userId = claims.get("userId").toString();
         this.role = Role.valueOf(claims.get("role").toString());
     }
 


### PR DESCRIPTION
## 개요
email에서 userId로 변경
카카오는 이메일을 가져오려면 동의를 무조건 받아야하기 때문에 가져오지 않아도 에러가 발생하지 않게 하기 위해서 카카오의 id 값을 가져오게 변경

## 작업사항

- user db의 email column을 userId column으로 변경

## 변경 로직 (Optional)
email에서 userId로 변경
userId에 값을 저장할 때에는 long형을 string형으로 변환하여 저장

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... describe:

## 이슈 번호
152
