### PR TITLE
[FE] 타임레코드 생성 시간 오류 해결

### DIFF
--- a/client/src/components/study/SubjectTime/SubjectTime.jsx
+++ b/client/src/components/study/SubjectTime/SubjectTime.jsx
@@ -12,6 +12,7 @@ import {
 } from "@recoil/timer-state";
 import { saveTime } from "@api/time-record-api";
 import { Play, Pause, GoalOpen } from "@icons";
+import { stringifyDate } from "@utils";
 import styles from "./SubjectTime.module.css";
 
 function SubjectTime({ onPlanBtnClick }) {
@@ -81,12 +82,12 @@ function SubjectTime({ onPlanBtnClick }) {
   }, [selectedPlan]);
 
   const saveStartTime = () => {
-    setStudyTime({ ...studyTime, start: new Date() });
+    setStudyTime({ ...studyTime, start: stringifyDate(new Date()) });
     setIsRecording(true);
   };
 
   const saveEndTime = () => {
-    setStudyTime({ ...studyTime, end: new Date() });
+    setStudyTime({ ...studyTime, end: stringifyDate(new Date()) });
     setIsRecording(false);
   };
 

--- a/client/src/utils/index.js
+++ b/client/src/utils/index.js
@@ -2,3 +2,4 @@ export { default as getColor } from "./getColor";
 export { default as getDday } from "./getDday";
 export { default as dateFormatting } from "./dateFormatting";
 export { default as dateParsing } from "./dateParsing";
+export { default as stringifyDate } from "./stringifyDate";

--- a/client/src/utils/stringifyDate.js
+++ b/client/src/utils/stringifyDate.js
@@ -1,0 +1,6 @@
+function stringifyDate(date) {
+  const offset = date.getTimezoneOffset() * 60000;
+  return new Date(date - offset).toISOString();
+}
+
+export default stringifyDate;


### PR DESCRIPTION
## 개요
Date 객체가 stringify되면서 UTC로 변환되는 문제 발생

## 변경 로직 (Optional)
> Date 객체를 timezone offset을 반영한 ISO string으로 변환
